### PR TITLE
Remove `resourcetool repl` as the default subcommand

### DIFF
--- a/src/commands/resourcetool/command.ts
+++ b/src/commands/resourcetool/command.ts
@@ -140,7 +140,6 @@ export const resourcetoolCommand = buildRouteMap({
       docs: { brief: "Run a script file" },
     }),
   },
-  defaultCommand: "repl",
   docs: {
     brief: "Programmatically read and manipulate project resources",
   },


### PR DESCRIPTION
Resolves #119 