### PR TITLE
Add 'windows.visualStudioSdk' toolchain option and support YYC on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.2.0
+
+- New feature: support for building with YYC on Windows. You must specify the 'visualStudioSdk' via `gm-options.json` or `--toolchain-options`. For example in the `gm-options.json` file: `"gms2": { "windows": { "visualStudioSdk": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\Common7\\Tools\\VsDevCmd.bat"}}`
+
 # 2.1.0
 
 - New feature: `--config` flag, used to set the project user config.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/YoYoGames/gm-cli"
   },
   "type": "module",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "files": [
     "dist",
     "NOTICE"

--- a/src/gm-options.ts
+++ b/src/gm-options.ts
@@ -80,6 +80,11 @@ export const gms2Schema = z
     windows: z
       .object({
         packageType: z.enum(["zip", "nsis"]),
+        visualStudioSdk: z
+          .string()
+          .describe(
+            "Path to VsDevCmd.bat, used when building with YYC. For example 'C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\Common7\\Tools\\VsDevCmd.bat'.",
+          ),
       })
       .partial(),
     mac: z

--- a/src/gms2/options.ts
+++ b/src/gms2/options.ts
@@ -21,6 +21,7 @@ export interface Gms2ToolchainOptions {
   };
   windows: {
     packageType?: "zip" | "nsis";
+    visualStudioSdk?: string;
   };
   mac: {
     packageType?: "zip" | "dmg";

--- a/src/gms2/use-gms2.ts
+++ b/src/gms2/use-gms2.ts
@@ -63,9 +63,13 @@ export async function useGms2(
     linux: options.toolchainOptions.linux ?? defaults.linux,
   };
 
-  if (runtime === "YYC" && options.target === "windows") {
+  if (
+    runtime === "YYC" &&
+    options.target === "windows" &&
+    !toolchainOptions.windows.visualStudioSdk
+  ) {
     throw new KnownError(
-      "Support for the native runtime (YYC) is coming soon to GameMaker CLI.",
+      "Building for Windows with YYC requires setting a path to the Visual Studio SDK.\nSet gms2.windows.visualStudioSdk in gm-options.json or --toolchain-options",
     );
   }
 
@@ -255,6 +259,10 @@ async function createLocalSettings(
   if (toolchainOptions.operagx.emscriptenSdk) {
     localSettings["machine.Platform Settings.operagx.sdk_dir"] =
       toolchainOptions.operagx.emscriptenSdk;
+  }
+  if (toolchainOptions.windows.visualStudioSdk) {
+    localSettings["machine.Platform Settings.Windows.visual_studio_path"] =
+      toolchainOptions.windows.visualStudioSdk;
   }
   // add more options here...
 


### PR DESCRIPTION
Confirmed to work on windows with `"gms2": { "windows": { "visualStudioSdk": "C:\\Program Files\\Microsoft Visual Studio\\18\\Community\\Common7\\Tools\\VsDevCmd.bat"} }`